### PR TITLE
make CodeMessageError hashable

### DIFF
--- a/aiorpcx/jsonrpc.py
+++ b/aiorpcx/jsonrpc.py
@@ -121,6 +121,11 @@ class CodeMessageError(Exception):
         return (isinstance(other, self.__class__) and
                 self.code == other.code and self.message == other.message)
 
+    def __hash__(self):
+        # overridden to make the exception hashable
+        # see https://bugs.python.org/issue28603
+        return hash((self.code, self.message))
+
     @classmethod
     def invalid_args(cls, message):
         return cls(JSONRPC.INVALID_ARGS, message)

--- a/tests/test_jsonrpc.py
+++ b/tests/test_jsonrpc.py
@@ -3,7 +3,7 @@ import json
 import pytest
 
 from aiorpcx import *
-from aiorpcx.jsonrpc import Response
+from aiorpcx.jsonrpc import Response, CodeMessageError
 from util import RaiseTest, assert_RPCError, assert_ProtocolError
 from random import shuffle
 
@@ -77,6 +77,10 @@ def test_abstract():
 
     with pytest.raises(NotImplementedError):
         MyProtocol._request_args({})
+
+
+def test_exception_is_hashable():
+    hash(CodeMessageError(0, ''))  # see if raises
 
 
 # ENCODING


### PR DESCRIPTION
see https://bugs.python.org/issue28603

It's very annoying and hard to debug when you lose exceptions completely as a task raised on the event loop and the code that was responsible for handling it also raised, due to the `traceback.print_exc` raising >.<