### PR TITLE
TaskGroup: faster cancellation

### DIFF
--- a/aiorpcx/curio.py
+++ b/aiorpcx/curio.py
@@ -202,8 +202,10 @@ class TaskGroup(object):
     async def cancel_remaining(self):
         '''Cancel all remaining tasks.'''
         self._closed = True
-        for task in list(self._pending):
+        task_list = list(self._pending)
+        for task in task_list:
             task.cancel()
+        for task in task_list:
             with suppress(CancelledError):
                 await task
 


### PR DESCRIPTION
before, only one task per event loop iteration would be cancelled

I have groups with ~3000 tasks.
Without this change, `cancel_remaining` takes 90 seconds; with it, it takes 3 seconds.