### PR TITLE
FinalRPCError(RPCError): send error to client and then disconnect

### DIFF
--- a/aiorpcx/jsonrpc.py
+++ b/aiorpcx/jsonrpc.py
@@ -27,7 +27,7 @@
 
 __all__ = ('JSONRPC', 'JSONRPCv1', 'JSONRPCv2', 'JSONRPCLoose',
            'JSONRPCAutoDetect', 'Request', 'Notification', 'Batch',
-           'RPCError', 'ProtocolError',
+           'RPCError', 'FinalRPCError', 'ProtocolError',
            'JSONRPCConnection', 'handler_invocation')
 
 import itertools
@@ -137,6 +137,10 @@ class CodeMessageError(Exception):
 
 
 class RPCError(CodeMessageError):
+    pass
+
+
+class FinalRPCError(RPCError):
     pass
 
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -63,6 +63,9 @@ class MyServerSession(RPCSession):
     async def on_bug(self):
         raise ValueError
 
+    async def on_incompatibleversion(self):
+        raise FinalRPCError(1, "incompatible version")
+
     async def on_sleepy(self):
         await sleep(10)
 
@@ -365,6 +368,14 @@ class TestRPCSession:
         except CancelledError:
             pass
         assert server_session.errors == server_session.max_errors
+
+    @pytest.mark.asyncio
+    async def test_finalrpcerror(self, server):
+        async with Connector(RPCSession, 'localhost',
+                             server.port) as client:
+            with pytest.raises(RPCError) as e:
+                await client.send_request('incompatibleversion')
+            assert client.is_closing()
 
     @pytest.mark.asyncio
     async def test_send_empty_batch(self, server):


### PR DESCRIPTION
as title, this PR lets user of this library to "send a final error" to connected session after which the connection gets closed

commit https://github.com/kyuupichan/aiorpcX/commit/3669108d2c774f4786bbfd5153c0359f10c500c2 removed `session.close_after_send`; and since then this functionality is difficult to accomplish