### PR TITLE
make websockets dependency optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
   - "nightly"
 # command to install dependencies
 install:
-  - pip install -e .
+  - pip install -e .[ws]
   - pip install uvloop
   - pip install pytest-asyncio
   - pip install pytest-cov

--- a/aiorpcx/websocket.py
+++ b/aiorpcx/websocket.py
@@ -26,7 +26,10 @@
 
 from functools import partial
 
-import websockets
+try:
+    import websockets
+except ImportError:
+    websockets = None
 
 from aiorpcx.curio import spawn
 from aiorpcx.session import RPCSession, SessionKind

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,10 @@ setuptools.setup(
     name='aiorpcX',
     version=version,
     python_requires='>=3.6',
-    install_requires=['websockets'],
+    install_requires=[],
+    extras_require={
+        'ws': 'websockets',
+    },
     packages=['aiorpcx'],
     description='Generic async RPC implementation, including JSON-RPC',
     author='Neil Booth',


### PR DESCRIPTION
Electrum uses aiorpcx, but we don't plan to use the websockets functionality for now.
For this reason, I would prefer making websockets an optional dependency.