### PR TITLE
Fix SOCKSRandomAuth on Python 3.8+, bump Travis Ubuntu/Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 language: python
 python:
   - "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - "3.6-dev"
   - "3.7-dev"
   - "3.8-dev"
+  - "3.9-dev"
   - "nightly"
 # command to install dependencies
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - "3.7-dev"
   - "3.8-dev"
   - "3.9-dev"
+  - "3.10-dev"
   - "nightly"
 # command to install dependencies
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,8 @@ script:
   - pycodestyle --max-line-length=100 aiorpcx/*.py
   - sh -c "cd docs && make html"
 after_success: coveralls
+jobs:
+  allow_failures:
+    - python: "3.8-dev"
+    - python: "3.9-dev"
+    - python: "3.10-dev"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "3.6"
   - "3.6-dev"
   - "3.7-dev"
+  - "3.8-dev"
   - "nightly"
 # command to install dependencies
 install:

--- a/aiorpcx/socks.py
+++ b/aiorpcx/socks.py
@@ -45,7 +45,7 @@ SOCKSUserAuth = collections.namedtuple("SOCKSUserAuth", "username password")
 
 # Random authentication is useful when used with Tor for stream isolation.
 class SOCKSRandomAuth(SOCKSUserAuth):
-    def __getitem__(self, key):
+    def __getattribute__(self, key):
         return secrets.token_hex(32)
 
 


### PR DESCRIPTION
`SOCKSRandomAuth` was broken on Python 3.8+ (both the username and password were returning `None`); this PR fixes it. Still works fine as far back as Python 3.6.0.

Feel free to cherry-pick just the bugfix commit if you don't want the Travis changes.