### PR TITLE
Fix SOCKSRandomAuth on Python 3.8+

### DIFF
--- a/aiorpcx/socks.py
+++ b/aiorpcx/socks.py
@@ -45,7 +45,7 @@ SOCKSUserAuth = collections.namedtuple("SOCKSUserAuth", "username password")
 
 # Random authentication is useful when used with Tor for stream isolation.
 class SOCKSRandomAuth(SOCKSUserAuth):
-    def __getitem__(self, key):
+    def __getattribute__(self, key):
         return secrets.token_hex(32)
 
 


### PR DESCRIPTION
`SOCKSRandomAuth` was broken on Python 3.8+ (both the username and password were returning `None`); this PR fixes it. Still works fine as far back as Python 3.6.0.