### PR TITLE
TaskGroup: enforce .join() is only called once

### DIFF
--- a/aiorpcx/curio.py
+++ b/aiorpcx/curio.py
@@ -104,6 +104,7 @@ class TaskGroup:
         self._logger = logging.getLogger(self.__class__.__name__)
         self._closed = False
         self.completed = None
+        self._joined = False
         for task in tasks:
             self._add_task(task)
 
@@ -178,6 +179,10 @@ class TaskGroup:
         Once join() returns, no more tasks may be added to the task
         group.  Tasks can be added while join() is running.
         '''
+        if self._joined:
+            raise RuntimeError("taskgroup already joined")
+        self._joined = True
+
         def errored(task):
             return not task.cancelled() and task.exception()
 


### PR DESCRIPTION
I have recently had a bug where inadvertently I was sometimes using the same taskgroup in multiple `async with` context managers, i.e. `join()` was called more than once. It was due to a quite unlikely race and a change like in this PR would have saved lots of time.

If one calls `join()` multiple times while the taskgroup is still "running", the behaviour is extremely hard to reason about: it depends on async timing.

https://github.com/kyuupichan/aiorpcX/blob/b01280bd2489e9b0f040a1881691330e61c47bac/aiorpcx/curio.py#L186-L189
https://github.com/kyuupichan/aiorpcX/blob/b01280bd2489e9b0f040a1881691330e61c47bac/aiorpcx/curio.py#L147-L156

All callers of join will await `_done_event.wait()` and then when any task finishes, all will get awaken.
If there is only one task "done", only the first caller will get to pop it, and the taskgroup gets cancelled by the other callers (as "done" looks empty to them). However, if  enough tasks finish ~simultaneously, all callers might be able to pop and get to await `_done_event.wait()` again.
I can't imagine any user of the library is relying on such behaviour. Calling `join()` multiple times is almost certainly a bug.