### PR TITLE
Bump websockets version to 14 and python version to 3.9

### DIFF
--- a/.azure-pipelines/ci.yml
+++ b/.azure-pipelines/ci.yml
@@ -63,18 +63,3 @@ jobs:
     name: Py39_Win
     vmImage: 'windows-latest'
     pythonVersion: '3.9'
-- template: run-tests.yml
-  parameters:
-    name: Py38_Ubuntu
-    vmImage: 'ubuntu-latest'
-    pythonVersion: '3.8'
-- template: run-tests.yml
-  parameters:
-    name: Py38_Mac
-    vmImage: 'macOS-latest'
-    pythonVersion: '3.8'
-- template: run-tests.yml
-  parameters:
-    name: Py38_Win
-    vmImage: 'windows-latest'
-    pythonVersion: '3.8'

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ library implementation of RPC suitable for an application that is a
 client, server or both.
 
   :Licence: MIT
-  :Language: Python (>= 3.8)
+  :Language: Python (>= 3.9)
   :Author: Neil Booth
 
 Documentation

--- a/aiorpcx/__init__.py
+++ b/aiorpcx/__init__.py
@@ -9,7 +9,7 @@ from .util import *
 from .websocket import *
 
 
-_version_str = '0.23.1'
+_version_str = '0.24.0'
 _version = tuple(int(part) for part in _version_str.split('.'))
 
 

--- a/aiorpcx/websocket.py
+++ b/aiorpcx/websocket.py
@@ -27,8 +27,7 @@
 from functools import partial
 
 try:
-    from websockets.client import connect
-    from websockets.server import serve
+    from websockets import connect, serve
     from websockets.exceptions import ConnectionClosed
 except ImportError:
     websockets = None
@@ -51,7 +50,7 @@ class WSTransport:
         self.closing = False
 
     @classmethod
-    async def ws_server(cls, session_factory, websocket, _path):
+    async def ws_server(cls, session_factory, websocket):
         transport = cls(websocket, session_factory, SessionKind.SERVER)
         await transport.process_messages()
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,11 @@ ChangeLog
           for a 1.0 release in the coming months.
 
 
+Version 0.24 (16 Jan 2024)
+----------------------------
+
+* bump websockets library to >=14.0 and Python version to >=3.9
+
 Version 0.23 (17 Mar 2024)
 ----------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = 'aiorpcX'
 dynamic = ['version', 'readme']
-requires-python = '>=3.8'
+requires-python = '>=3.9'
 dependencies = []
 description = 'Generic async RPC implementation, including JSON-RPC'
 authors = [{name = 'Neil Booth', email = 'kyuupichan@pm.me'}]
@@ -17,10 +17,10 @@ classifiers = [
   'Intended Audience :: Developers',
   'License :: OSI Approved :: MIT License',
   'Operating System :: OS Independent',
-  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
   'Topic :: Internet',
   "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 
 [project.optional-dependencies]
-'ws' = ['websockets>=12.0']
+'ws' = ['websockets>=14.0']

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ version = find_version(os.path.join(tld, 'aiorpcx', '__init__.py'))
 
 setuptools.setup(
     version=version,
-    python_requires='>=3.8',
+    python_requires='>=3.9',
     packages=['aiorpcx'],
     # Tell setuptools to include data files specified by MANIFEST.in.
     include_package_data=True,

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -7,19 +7,12 @@ from aiorpcx import connect_ws, NetAddress, serve_ws
 from test_session import MyServerSession
 
 
-@pytest.fixture
-def ws_server(unused_tcp_port, event_loop):
-    coro = serve_ws(MyServerSession, 'localhost', unused_tcp_port)
-    server = event_loop.run_until_complete(coro)
+@pytest.fixture(scope="function")
+async def ws_server(unused_tcp_port, event_loop):
+    server = await serve_ws(MyServerSession, 'localhost', unused_tcp_port)
     yield f'ws://localhost:{unused_tcp_port}'
-    tasks = asyncio.all_tasks(event_loop)
-
-    async def close_all():
-        server.close()
-        await server.wait_closed()
-        if tasks:
-            await asyncio.wait(tasks)
-    event_loop.run_until_complete(close_all())
+    server.close()
+    await server.wait_closed()
 
 
 @pytest.mark.filterwarnings("ignore:'with .*:DeprecationWarning")


### PR DESCRIPTION
Version 14 of websockets [depreceated](https://websockets.readthedocs.io/en/stable/howto/upgrade.html) the api currently in use by aiorpcX and requires a minimal Python version of 3.9. 
This causes these warnings when using aiorpcX with the new websockets version: 
```
venv/lib/python3.9/site-packages/aiorpcx/websocket.py:30
  /home/electrum/trash/aiorpcX-fork/venv/lib/python3.9/site-packages/aiorpcx/websocket.py:30: DeprecationWarning: websockets.client.connect is deprecated
    from websockets.client import connect

venv/lib/python3.9/site-packages/websockets/legacy/__init__.py:6
  /home/electrum/trash/aiorpcX-fork/venv/lib/python3.9/site-packages/websockets/legacy/__init__.py:6: DeprecationWarning: websockets.legacy is deprecated; see https://websockets.readthedocs.io/en/stable/howto/upgrade.html for upgrade instructions
    warnings.warn(  # deprecated in 14.0 - 2024-11-09

venv/lib/python3.9/site-packages/aiorpcx/websocket.py:31
  /home/electrum/trash/aiorpcX-fork/venv/lib/python3.9/site-packages/aiorpcx/websocket.py:31: DeprecationWarning: websockets.server.serve is deprecated
    from websockets.server import serve
```

This PR changes the imports and one test function to work with the new websockets 14 api, increases the required Python version to >=3.9 and adds a new release note for a version 24.0. Also CI tests with python3.8 are removed.
All tests passed on my machine.